### PR TITLE
An idea to avoid reflection

### DIFF
--- a/OpenClose/src/openClose/AbstractEmployee.java
+++ b/OpenClose/src/openClose/AbstractEmployee.java
@@ -1,12 +1,10 @@
 package openClose;
 
-public class AbstractEmployee {
-	private int id;
-	private float hours;
+public abstract class AbstractEmployee implements Employee {
+	int id;
+	float hours;
 
-	public AbstractEmployee(int id, float hours) {
-		this.id = id;
-		this.hours = hours;
+	AbstractEmployee() {
 	}
 
 	public int getId() {

--- a/OpenClose/src/openClose/Contractor.java
+++ b/OpenClose/src/openClose/Contractor.java
@@ -1,12 +1,11 @@
 package openClose;
 
-public class Contractor extends AbstractEmployee implements Employee {
+public class Contractor extends AbstractEmployee {
 
 	private static final int MIN_WEEKLY_PAY = 20_000;
 	private static final int HOURLY_PAY = 1_200;
 
-	public Contractor(int id, float hours) {
-		super(id, hours);
+	Contractor() {
 	}
 
 	@Override

--- a/OpenClose/src/openClose/Employee.java
+++ b/OpenClose/src/openClose/Employee.java
@@ -3,7 +3,4 @@ package openClose;
 public interface Employee {
 
 	float weeklyPay();
-	static Employee create(int id, float hours) {
-		return null;
-	}
 }

--- a/OpenClose/src/openClose/EmployeeDbMapper.java
+++ b/OpenClose/src/openClose/EmployeeDbMapper.java
@@ -1,34 +1,32 @@
 package openClose;
 
-import java.lang.reflect.Constructor;
-
 public class EmployeeDbMapper {
-	public static Employee create(int id, float hours, int type) {
-		try {
-			Constructor<? extends Employee> constructor = EmployeeType.SALARIED.getConstructor();
-			return constructor.newInstance(id, hours);
-		} catch (Exception e) {
-			e.printStackTrace();
-		}
-
-		return null;
+	public static Employee create(int id, float hours, String type) {
+	    EmployeeType employeeType = EmployeeType.valueOf(type);
+	    return employeeType.getEmployee(id, hours);
 	}
 	
 	private enum EmployeeType {
-		SALARIED(0, SalariedEmployee.class),
-		INTERN(1, Intern.class), 
-		CONTRACTOR(2, Contractor.class);
+		SALARIED(SalariedEmployee.class),
+		INTERN(Intern.class), 
+		CONTRACTOR(Contractor.class);
 		
-		private int type;
 		private Class<? extends Employee> clazz;
 
-		EmployeeType(int type, Class<? extends Employee> clazz) {
-			this.type = type;
+		EmployeeType(Class<? extends Employee> clazz) {
 			this.clazz = clazz;
 		}
 
-		public Constructor<? extends Employee> getConstructor() throws NoSuchMethodException, SecurityException {
-			return clazz.getConstructor(int.class, float.class);
+		public Employee getEmployee(int id, float hours) {
+		    try {
+			AbstractEmployee employee = (AbstractEmployee) clazz.newInstance();
+			employee.id = id;
+			employee.hours = hours;
+			return employee;
+		    } catch (IllegalAccessException|InstantiationException e) {
+			e.printStackTrace();
+			return null;
+		    }
 		}
 	}	
 }

--- a/OpenClose/src/openClose/EmployeeDbMapper.java
+++ b/OpenClose/src/openClose/EmployeeDbMapper.java
@@ -11,15 +11,15 @@ public class EmployeeDbMapper {
 		INTERN(Intern.class), 
 		CONTRACTOR(Contractor.class);
 		
-		private Class<? extends Employee> clazz;
+		private Class<? extends AbstractEmployee> clazz;
 
-		EmployeeType(Class<? extends Employee> clazz) {
+		EmployeeType(Class<? extends AbstractEmployee> clazz) {
 			this.clazz = clazz;
 		}
 
 		public Employee getEmployee(int id, float hours) {
 		    try {
-			AbstractEmployee employee = (AbstractEmployee) clazz.newInstance();
+			AbstractEmployee employee = clazz.newInstance();
 			employee.id = id;
 			employee.hours = hours;
 			return employee;

--- a/OpenClose/src/openClose/Intern.java
+++ b/OpenClose/src/openClose/Intern.java
@@ -1,11 +1,10 @@
 package openClose;
 
-public class Intern extends AbstractEmployee implements Employee {
+public class Intern extends AbstractEmployee {
 
 	private static final int HOURLY_PAY = 500;
 	
-	public Intern(int id, float hours) {
-		super(id, hours);
+	Intern() {
 	}
 
 	@Override

--- a/OpenClose/src/openClose/SalariedEmployee.java
+++ b/OpenClose/src/openClose/SalariedEmployee.java
@@ -1,11 +1,10 @@
 package openClose;
 
-public class SalariedEmployee extends AbstractEmployee implements Employee {
+public class SalariedEmployee extends AbstractEmployee {
 
 	private static final int HOURLY_PAY = 1_000;
 	
-	public SalariedEmployee(int id, float hours) {
-		super(id, hours);
+	SalariedEmployee() {
 	}
 
 	@Override


### PR DESCRIPTION
This is one idea.  It uses package level access to make the constructors
and internal members only available to the builder in the enum.  The
only thing I dislike about this is the cast in the enum builder method.
This could be avoided by adding a "initialize" method to the interface,
but I didn't like that any better.
